### PR TITLE
Corrected return value of isSupported() and isImmersiveModeSupported()

### DIFF
--- a/src/android/com/mesmotronic/plugins/FullScreenPlugin.java
+++ b/src/android/com/mesmotronic/plugins/FullScreenPlugin.java
@@ -77,7 +77,7 @@ public class FullScreenPlugin extends CordovaPlugin
 		
         PluginResult res = new PluginResult(PluginResult.Status.OK, supported);
         context.sendPluginResult(res);
-		return true;
+		return supported;
 	}
 	
 	/**
@@ -89,7 +89,7 @@ public class FullScreenPlugin extends CordovaPlugin
 		
         PluginResult res = new PluginResult(PluginResult.Status.OK, supported);
         context.sendPluginResult(res);
-		return true;
+		return supported;
 	}
 	
 	/**


### PR DESCRIPTION
When for example calling immersiveMode() it will always try to do it because you check for isImmersiveModeSupported() but when it always returns true it is absolutely senseless... same with all the other functions.
Since "isSupported()" and "isImmersiveModeSupported()" always return true the if-statement to check if they are false is pretty useless :/